### PR TITLE
Increase testability of `Restaurants` component and make "name-*" sort methods case-insensitive

### DIFF
--- a/src/app/location/[postcode]/page.tsx
+++ b/src/app/location/[postcode]/page.tsx
@@ -33,12 +33,12 @@ const sortRestaurantData = (
             break;
         case "name-asc":
             sorted = sorted = restaurants.sort((a, b) =>
-                a.name > b.name ? 1 : -1,
+                a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1,
             );
             break;
         case "name-desc":
             sorted = sorted = restaurants.sort((a, b) =>
-                a.name < b.name ? 1 : -1,
+                a.name.toLowerCase() < b.name.toLowerCase() ? 1 : -1,
             );
             break;
     }

--- a/src/app/location/[postcode]/page.tsx
+++ b/src/app/location/[postcode]/page.tsx
@@ -85,13 +85,12 @@ const getRestaurantsByPostcode = async (
     return null;
 };
 
-type SearchParams = Record<string, string | string[] | undefined>;
 export default async function ResultsPage({
     params,
     searchParams,
 }: {
     params: { postcode: string };
-    searchParams: SearchParams;
+    searchParams: Record<string, string | string[] | undefined>;
 }) {
     return (
         <section>

--- a/src/app/location/[postcode]/page.tsx
+++ b/src/app/location/[postcode]/page.tsx
@@ -100,8 +100,8 @@ export default async function ResultsPage({
             <Suspense fallback={<>Loading...</>}>
                 <Restaurants
                     postcode={params.postcode}
-                    // Use default sort order if "sort" param is null/undefined
-                    sortBy={(searchParams.sort ?? "default") as SortOption}
+                    sortBy={(searchParams.sort ?? "default") as SortOption} // Use default sort order if "sort" param is null/undefined
+                    fetcher={getRestaurantsByPostcode}
                 />
             </Suspense>
         </section>
@@ -121,11 +121,16 @@ export async function generateMetadata({
 const Restaurants = async ({
     postcode,
     sortBy,
+    fetcher,
 }: {
     postcode: string;
     sortBy: SortOption;
+    fetcher: (
+        postcode: string,
+        sortBy?: SortOption,
+    ) => Promise<LimitedEnrichedRestaurantsResponse | null>;
 }) => {
-    const data = await getRestaurantsByPostcode(postcode, sortBy);
+    const data = await fetcher(postcode, sortBy);
     if (data === null) {
         return <>⚠️ No data</>;
     }


### PR DESCRIPTION
### `<Restaurants />`
Increase the testability of the `<Restaurants />` component by decoupling the `fetch()` network call from it. It now takes in a `fetcher` function (with the same signature as `getRestaurantsByPostcode()`, which previously was directly invoked from this component). This abstracts away implementation details of how the data is retrieved, ensuring that `<Restaurants />` is only focused on rendering the UI using the given data (regardless of where it comes from). This increases its testability as `fetcher` can be a function that returns hardcoded data in a test environment, eliminating the need to make network calls in tests.

### `sortRestaurantData`
"name-asc" and "name-desc" sort methods are no longer case-sensitive. This fixes unexpected behaviour - e.g., if sorting by "name-asc", a restaurant with a name starting with "A" would appear first, but one starting with "a" would appear after all other restaurants that have names starting with a capital letter.